### PR TITLE
Fixed failing tests

### DIFF
--- a/test/test.conf.js
+++ b/test/test.conf.js
@@ -2,9 +2,9 @@ basePath = '..';
 files = [
   JASMINE,
   JASMINE_ADAPTER,
-  'components/angular/angular.js',
-  'components/angular-mocks/angular-mocks.js',
-  'components/tinymce/tinymce.min.js',
+  'bower_components/angular/angular.js',
+  'bower_components/angular-mocks/angular-mocks.js',
+  'bower_components/tinymce/tinymce.min.js',
   'src/tinymce.js',
   'test/*.spec.js'
 ];


### PR DESCRIPTION
Bower changed the default location that dependencies are installed in from `components` to `bower_components` - this PR is a simple fix to that.
