### PR TITLE
Propagate click events to original textarea

### DIFF
--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -70,9 +70,7 @@ angular.module('ui.tinymce', [])
           }
           if (tinyInstance) {
             tinyInstance.setContent(ngModel.$viewValue || '');
-          }
 
-          if (tinyInstance) {
             var contentAreaContainer = angular.element(tinyInstance.contentAreaContainer);
 
             contentAreaContainer.find('iframe')[0].contentWindow.document.body.onclick = function () {

--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -76,7 +76,7 @@ angular.module('ui.tinymce', [])
             contentAreaContainer.find('iframe')[0].contentWindow.document.body.onclick = function () {
               var event = document.createEvent('MouseEvent');
               event.initEvent('click', true, true);
-              contentAreaContainer[0].dispatchEvent(event);
+              elm[0].dispatchEvent(event);
             };
           }
         };

--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -63,7 +63,6 @@ angular.module('ui.tinymce', [])
         setTimeout(function () {
           tinymce.init(options);
         });
-        
 
         ngModel.$render = function() {
           if (!tinyInstance) {
@@ -71,6 +70,16 @@ angular.module('ui.tinymce', [])
           }
           if (tinyInstance) {
             tinyInstance.setContent(ngModel.$viewValue || '');
+          }
+
+          if (tinyInstance) {
+            var contentAreaContainer = angular.element(tinyInstance.contentAreaContainer);
+
+            contentAreaContainer.find('iframe')[0].contentWindow.document.body.onclick = function () {
+              var event = document.createEvent('MouseEvent');
+              event.initEvent('click', true, true);
+              contentAreaContainer[0].dispatchEvent(event);
+            };
           }
         };
       }


### PR DESCRIPTION
In the app I am working on, I need to know when the user clicks inside of
TinyMCE. Because TinyMCE is in an `iframe`, the events do not propagate when the
`iframe` is the event target.

This change will trigger a click event on the original `textarea` element.