### PR TITLE
Fixed .gitignore, fixed demo.html reference to dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-components/
+bower_components/
 node_modules/

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -7,8 +7,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <title>AngularUI - TinyMCE Demo</title>
-  <script type="text/javascript" src="../components/tinymce/tinymce.min.js"></script>
-  <script type="text/javascript" src="../components/angular/angular.js"></script>
+  <script type="text/javascript" src="../bower_components/tinymce/tinymce.min.js"></script>
+  <script type="text/javascript" src="../bower_components/angular/angular.js"></script>
   <script type="text/javascript" src="../src/tinymce.js"></script>
 </head>
 <body ng-app="ui.tinymce">


### PR DESCRIPTION
With the change to `bower_components` for the default Bower install location, the .gitignore and demo was off.  This PR fixes this.
