### PR TITLE
Prevent the view to be updated when the the setContent is called during init

### DIFF
--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -45,8 +45,10 @@ angular.module('ui.tinymce', [])
             });
             // Update model on change, i.e. copy/pasted text, plugins altering content
             ed.on('SetContent', function (e) {
-              ed.save();
-              updateView();
+              if(!e.initial){
+                ed.save();
+                updateView();
+              }
             });
             if (expression.setup) {
               scope.$eval(expression.setup);


### PR DESCRIPTION
Hi there

This change will prevent calling the setContent which is called by tinymce when the initialization is firing.
During this phase the element (textarea or div) does not yet have a value, resulting in an empty editor when there is actually data to show.

I have seen more examples in other forks where people try to fix this, but I think this is the most elegant way to do it, because tinymce will actually tell you that it is calling the setContent during initialization.

thanks in advance

Ronald van der Kooij
