### PR TITLE
Check $$phase on the root scope

### DIFF
--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -12,7 +12,7 @@ angular.module('ui.tinymce', [])
         var expression, options, tinyInstance,
           updateView = function () {
             ngModel.$setViewValue(elm.val());
-            if (!scope.$$phase) {
+            if (!scope.$root.$$phase) {
               scope.$apply();
             }
           };


### PR DESCRIPTION
Checking $$phase on the directive scope is not good enough since $$phase is defined on the root scope.
If there's an isolated scope in the chain, it will break.
