### PR TITLE
configured setup option no longer overwrites setup in directive

### DIFF
--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -26,6 +26,13 @@ angular.module('ui.tinymce', [])
         } else {
           expression = {};
         }
+
+        // make config'ed setup method available
+        if (expression.setup) {
+          var configSetup = expression.setup;
+          delete expression.setup;
+        }
+
         options = {
           // Update model when calling setContent (such as from the source editor popup)
           setup: function (ed) {
@@ -50,9 +57,8 @@ angular.module('ui.tinymce', [])
                 updateView();
               }
             });
-            if (expression.setup) {
-              scope.$eval(expression.setup);
-              delete expression.setup;
+            if (configSetup) {
+              configSetup(ed);
             }
           },
           mode: 'exact',


### PR DESCRIPTION
Currently, if I define a `setup` method in my tinymce config, it overwrites the entire `setup` option that is defined in the tinymce directive. This change moves deleting `expression.setup` out of the directive's `setup` function so it doesn't end up overwriting it when the options are extended with the `expression`.
