### PR TITLE
fixing custom setup functions

### DIFF
--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -26,7 +26,11 @@ angular.module('ui.tinymce', [])
         } else {
           expression = {};
         }
-        userSetup = delete expression.setup;
+        
+        if (expression.setup) {
+          userSetup = expression.setup;
+          delete expression.setup;
+        }
         options = {
           // Update model when calling setContent (such as from the source editor popup)
           setup: function (ed) {
@@ -52,7 +56,7 @@ angular.module('ui.tinymce', [])
               }
             });
             if (userSetup) {
-              scope.$eval(userSetup);
+              userSetup.apply(scope, [ed]);
             }
           },
           mode: 'exact',

--- a/test/tinymce.spec.js
+++ b/test/tinymce.spec.js
@@ -23,7 +23,7 @@ describe('uiTinymce', function () {
    */
   function compile() {
     runs(function () {
-      element = $compile('<form><textarea id="foo" ui-tinymce="{foo: \'bar\', setup: setupFooBar() }" ng-model="foo"></textarea></form>')(scope);
+      element = $compile('<form><textarea id="foo" ui-tinymce="{foo: \'bar\', setup: setupFooBar }" ng-model="foo"></textarea></form>')(scope);
       angular.element(document.getElementsByTagName('body')[0]).append(element);
     });
     scope.$apply();
@@ -40,7 +40,7 @@ describe('uiTinymce', function () {
         expect(tinymce.init.mostRecentCall.args[0].foo).toEqual('bar');
       });
     });
-
+    
     it('should include the default options', function () {
       spyOn(tinymce, 'init');
       compile();


### PR DESCRIPTION
I noticed that, when I tried to use a custom setup function, the directive stopped working.  Turned out that, as far as I could tell, the custom setup function was overriding the directive's internal setup function, so tinymce was never getting initiated properly.

There's a fix and a test in here.
