### PR TITLE
Fixed bug with setup on options

### DIFF
--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -58,7 +58,6 @@ angular.module('ui.tinymce', [])
           });
           if (expression.setup) {
             expression.setup(ed);
-            delete expression.setup;
           }
         };
         setTimeout(function () {


### PR DESCRIPTION
The scope.$eval(expression.setup); line is not being evaluated since the setup function gets redefined on line 62 (before the setup function is executed).
