### PR TITLE
Implemented functionality to handle onChange events from TinyMCE

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,16 +51,16 @@ Apply the directive to your form elements:
 All the TinyMCE options can be passed through the directive.
 
 	myAppModule.controller('MyController', function($scope) {
-		$scope.tinymceOptions = {
-			handle_event_callback: function (e) {
-        // put logic here for keypress
-      }
-		};
+	  $scope.tinymceOptions = {
+	    onChange: function (e) {
+	      // put logic here for keypress and cut/paste changes
+	    }
+	  };
 	});
 
-    <form method="post">
-      <textarea ui-tinymce="tinymceOptions" ng-model="tinymceModel"></textarea>
-    </form>
+	<form method="post">
+	  <textarea ui-tinymce="tinymceOptions" ng-model="tinymceModel"></textarea>
+	</form>
 
 ## Working with ng-model
 

--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -15,6 +15,9 @@ angular.module('ui.tinymce', [])
             if (!scope.$root.$$phase) {
               scope.$apply();
             }
+            if (typeof options.onChange === 'function') {
+              options.onChange();
+            }
           };
         // generate an ID if not present
         if (!attrs.id) {


### PR DESCRIPTION
The existing "handle_event_callback" functionality is not implemented.  I renamed the option name to match TinyMCE's conventions and implemented it.  It works for all changes to the content including cut/paste.