### PR TITLE
Update model when an object has been resized

### DIFF
--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -50,6 +50,11 @@ angular.module('ui.tinymce', [])
                 updateView();
               }
             });
+            // Update model when an object has been resized (table, image)
+            ed.on('ObjectResized', function (e) {
+              ed.save();
+              updateView();
+            });
             if (expression.setup) {
               scope.$eval(expression.setup);
               delete expression.setup;


### PR DESCRIPTION
There was a conflict with the plugin table and when we resized images.
ng-model was not updated correctly.
Update the ng-model on resized.
