### PR TITLE
Updated bower to include tinyMCE from the official repo

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
   ],
   "dependencies": {
     "angular": "~1.x",
-    "tinymce": "git@github.com:jozzhart/tinymce.git#4.0.22"
+    "tinymce": "~4.0.22"
   },
   "devDependencies": {
     "angular-mocks": "~1.x"


### PR DESCRIPTION
Currently the `bower.json` is requiring tinyMCE from another repo that doesn't have a bower file & doesn't have a 'main' property. This means that compiling tinyMCE via grunt or brunch will not work.

I changed it to have a dependency on the official tinyMCE repository (which has a bower.json file).
