### PR TITLE
Updated bower.json to depend on the offical repo for TinyMCE

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-ui-tinymce",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "This directive allows you to TinyMCE in your form.",
   "author": "https://github.com/angular-ui/ui-tinymce/graphs/contributors",
   "license": "MIT",

--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
   ],
   "dependencies": {
     "angular": "~1.x",
-    "tinymce": "git@github.com:jozzhart/tinymce.git#4.0.22"
+    "tinymce": "~4.0.22"
   },
   "devDependencies": {
     "angular-mocks": "~1.x"

--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
   ],
   "dependencies": {
     "angular": "~1.x",
-    "tinymce": "~4.0.22"
+    "tinymce": "~4.1.0"
   },
   "devDependencies": {
     "angular-mocks": "~1.x"

--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
   "dependencies": {},
   "devDependencies": {
     "grunt": "~0.4.4",
-    "grunt-karma": "~0.8.2",
     "grunt-contrib-jshint": "~0.10.0",
     "grunt-conventional-changelog": "~1.0.0",
-    "karma-jasmine": "~0.2.2",
+    "grunt-karma": "~0.8.2",
     "karma-chrome-launcher": "~0.1.3",
-    "karma-firefox-launcher": "~0.1.3",
+    "karma-firefox-launcher": "^0.1.3",
+    "karma-jasmine": "~0.2.2",
     "load-grunt-tasks": "~0.2.0"
   },
   "scripts": {},

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -5,7 +5,7 @@ module.exports = function (config) {
     files: [
       'bower_components/angular/angular.js',
       'bower_components/angular-mocks/angular-mocks.js',
-      'bower_components/tinymce/tinymce.min.js',
+      'bower_components/tinymce/tinymce.js',
       'src/tinymce.js',
       'test/*.spec.js',
       {pattern: 'bower_components/tinymce/themes/modern/theme.min.js', served: true},
@@ -13,6 +13,6 @@ module.exports = function (config) {
     ],
     singleRun: false,
     autoWatch: true,
-    browsers: [ 'Chrome' ],
+    browsers: [ 'Chrome', 'Firefox' ],
   });
 };

--- a/test/tinymce.spec.js
+++ b/test/tinymce.spec.js
@@ -66,7 +66,8 @@ describe('uiTinymce', function () {
 
       scope.$destroy();
 
-      expect(tinymce.get('foo')).toBeUndefined();
+      // This could either be undefined or null, so check for both
+      expect(tinymce.get('foo')).toBeFalsy();
 
       done();
     });


### PR DESCRIPTION
Currently the `bower.json` is requiring tinyMCE from another repo that doesn't have a bower file & doesn't have a 'main' property. This means that compiling tinyMCE via grunt or brunch will not work.

I changed it to have a dependency on the official tinyMCE repository (which has a bower.json file).