### PR TITLE
Added tinymce new 4.1.0 release.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bower_components/
 node_modules/
+.idea/

--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
   ],
   "dependencies": {
     "angular": "~1.x",
-    "tinymce": "git@github.com:jozzhart/tinymce.git#4.0.22"
+    "tinymce": "~4.x"
   },
   "devDependencies": {
     "angular-mocks": "~1.x"

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-ui-tinymce",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "This directive allows you to TinyMCE in your form.",
   "author": "https://github.com/angular-ui/ui-tinymce/graphs/contributors",
   "license": "MIT",


### PR DESCRIPTION
There is an official tinymce-dist bower package with new 4.1.0 release that supports bunch of new plugins (e.g. colorpicker). See here: http://www.tinymce.com/forum/viewtopic.php?id=33972. Link to the official repository: https://github.com/tinymce/tinymce-dist.