### PR TITLE
Permission Denied fix

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
   ],
   "dependencies": {
     "angular": "~1.x",
-    "tinymce": "git@github.com:jozzhart/tinymce.git#4.0.22"
+    "tinymce": "git://github.com/jozzhart/tinymce.git#4.0.22"
   },
   "devDependencies": {
     "angular-mocks": "~1.x"


### PR DESCRIPTION
As defined on https://github.com/bower/bower#installing-packages-and-dependencies, `https://github.com/someone/some-package.git` and `git@github.com:someone/some-package.git` will treat the repos as private and try to authenticate via prompt or SSH keys. This is problematic for a Staging/Production server that doesnt have a github account.

Switching to `git://github.com/jozzhart/tinymce.git#4.0.22` should resolve the issue.