### PR TITLE
Update tinymce.js to read from editor on change

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
   ],
   "dependencies": {
     "angular": "~1.x",
-    "tinymce": "git@github.com:jozzhart/tinymce.git#4.0.22"
+    "tinymce": "~4.0.16"
   },
   "devDependencies": {
     "angular-mocks": "~1.x"

--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -6,13 +6,12 @@ angular.module('ui.tinymce', [])
   .directive('uiTinymce', ['uiTinymceConfig', function (uiTinymceConfig) {
     uiTinymceConfig = uiTinymceConfig || {};
     var generatedIds = 0;
-    var editor;
 
     return {
       priority: 10,
       require: 'ngModel',
       link: function (scope, elm, attrs, ngModel) {
-        var expression, options, tinyInstance,
+        var editor, expression, options, tinyInstance,
           updateView = function () {
             ngModel.$setViewValue(editor.getContent({ format : 'raw' }));
             if (!scope.$root.$$phase) {

--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -13,9 +13,14 @@ angular.module('ui.tinymce', [])
       link: function (scope, elm, attrs, ngModel) {
         var editor, expression, options, tinyInstance,
           updateView = function () {
-            ngModel.$setViewValue(editor.getContent({ format : 'raw' }));
-            if (!scope.$root.$$phase) {
-              scope.$apply();
+            var v = editor.getContent({ format : 'raw' });
+            var newStripped = v.replace(/\s+/g,'');
+            var curStripped = ngModel.$viewValue.replace(/\s+/g,' ');
+            if (newStripped !== curStripped) {
+              ngModel.$setViewValue(v);
+              if (!scope.$root.$$phase) {
+                scope.$apply();
+              }
             }
           };
 

--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -14,8 +14,8 @@ angular.module('ui.tinymce', [])
         var editor, expression, options, tinyInstance,
           updateView = function () {
             var v = editor.getContent({ format : 'raw' });
-            var newStripped = v.replace(/\s+/g,'');
-            var curStripped = ngModel.$viewValue.replace(/\s+/g,' ');
+            var newStripped = v.replace(/\s+/gm,' ');
+            var curStripped = ngModel.$viewValue.replace(/\s+/gm,' ');
             if (newStripped !== curStripped) {
               ngModel.$setViewValue(v);
               if (!scope.$root.$$phase) {

--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -12,7 +12,7 @@ angular.module('ui.tinymce', [])
       link: function (scope, elm, attrs, ngModel) {
         var expression, options, tinyInstance,
           updateView = function () {
-            ngModel.$setViewValue(elm.val());
+            ngModel.$setViewValue(editor.getContent({ format : 'raw' }));
             if (!scope.$root.$$phase) {
               scope.$apply();
             }

--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -7,6 +7,10 @@ angular.module('ui.tinymce', [])
     uiTinymceConfig = uiTinymceConfig || {};
     var generatedIds = 0;
 
+    function simple(v) {
+      return v.replace(/\s+/g,'');
+    }
+
     return {
       priority: 10,
       require: 'ngModel',
@@ -14,8 +18,9 @@ angular.module('ui.tinymce', [])
         var editor, expression, options, tinyInstance,
           updateView = function () {
             var v = editor.getContent({ format : 'raw' });
-            var newStripped = v.replace(/\s+/gm,' ');
-            var curStripped = ngModel.$viewValue.replace(/\s+/gm,' ');
+            var newStripped = simple(v);
+            var curStripped = simple(ngModel.$viewValue);
+            
             if (newStripped !== curStripped) {
               ngModel.$setViewValue(v);
               if (!scope.$root.$$phase) {

--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -6,6 +6,8 @@ angular.module('ui.tinymce', [])
   .directive('uiTinymce', ['uiTinymceConfig', function (uiTinymceConfig) {
     uiTinymceConfig = uiTinymceConfig || {};
     var generatedIds = 0;
+    var editor;
+
     return {
       priority: 10,
       require: 'ngModel',
@@ -38,6 +40,8 @@ angular.module('ui.tinymce', [])
         options = {
           // Update model when calling setContent (such as from the source editor popup)
           setup: function (ed) {
+            editor = ed;
+            
             var args;
             ed.on('init', function(args) {
               ngModel.$render();


### PR DESCRIPTION
The fix below makes the directive read the content from the editor and not the dom (fixing issues with entity conversion).  I was having issues with the directive flip/flopping entities on me causing the directive to cause unnecessary digest cycles.  It also caused the editor to completely replace the contents which forced the cursor to the beginning of the document.