### PR TITLE
Fixed script references in README to .min.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ bower install
 This will copy the ui-tinymce files into your `components` folder, along with its dependencies. Load the script files in your application:
 
 ```html
-<script type="text/javascript" src="app/bower_components/tinymce/tinymce.js"></script>
-<script type="text/javascript" src="app/bower_components/angular/angular.js"></script>
+<script type="text/javascript" src="app/bower_components/tinymce/tinymce.min.js"></script>
+<script type="text/javascript" src="app/bower_components/angular/angular.min.js"></script>
 <script type="text/javascript" src="app/bower_components/angular-ui-tinymce/tinymce.js"></script>
 ```
 


### PR DESCRIPTION
Straight forward.  These script references don't work otherwise if you've followed the instructions in the README as they stand.
