### PR TITLE
Setup runs on all instantiations

### DIFF
--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -12,6 +12,7 @@ angular.module('ui.tinymce', [])
       link: function (scope, elm, attrs, ngModel) {
         var expression, options, tinyInstance,
           updateView = function () {
+			console.log(elm.val());
             ngModel.$setViewValue(elm.val());
             if (!scope.$root.$$phase) {
               scope.$apply();

--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -28,16 +28,17 @@ angular.module('ui.tinymce', [])
         } else {
           expression = {};
         }
+		
+		options = {
+          mode: 'exact',
+          elements: attrs.id
+		}
+        // extend options with initial uiTinymceConfig and options from directive attribute value
+        angular.extend(options, uiTinymceConfig, expression);
 
-        // make config'ed setup method available
-        if (expression.setup) {
-          var configSetup = expression.setup;
-          delete expression.setup;
-        }
-
-        options = {
+        options.setup = 
           // Update model when calling setContent (such as from the source editor popup)
-          setup: function (ed) {
+          function (ed) {
             var args;
             ed.on('init', function(args) {
               ngModel.$render();
@@ -68,15 +69,11 @@ angular.module('ui.tinymce', [])
               ed.save();
               updateView();
             });
-            if (configSetup) {
-              configSetup(ed);
+            if (expression.setup) {
+              expression.setup(ed);
             }
-          },
-          mode: 'exact',
-          elements: attrs.id
-        };
-        // extend options with initial uiTinymceConfig and options from directive attribute value
-        angular.extend(options, uiTinymceConfig, expression);
+          }
+		
         setTimeout(function () {
           tinymce.init(options);
         });

--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -12,7 +12,6 @@ angular.module('ui.tinymce', [])
       link: function (scope, elm, attrs, ngModel) {
         var expression, options, tinyInstance,
           updateView = function () {
-			console.log(elm.val());
             ngModel.$setViewValue(elm.val());
             if (!scope.$root.$$phase) {
               scope.$apply();


### PR DESCRIPTION
When a ui-tinymce element comes into being thanks to new elements being added to a range used by ng-repeat any custom setup methods would not be run for the subsequent additions.

This was caused by deleting the setup from the expression.  Instead of doing that, we can rearrange where we do the angular.extend and not clobber the internal setup with the expression.setup.