### PR TITLE
cleanup in directive instead of scope

### DIFF
--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -90,8 +90,10 @@ angular.module('ui.tinymce', [])
           }
         };
 
-        scope.$on('$destroy', function() {
-          if (!tinyInstance) { tinyInstance = tinymce.get(attrs.id); }
+        elm.on('$destroy', function() {
+          if (!tinyInstance) {
+            tinyInstance = tinymce.get(attrs.id);
+          }
           if (tinyInstance) {
             tinyInstance.remove();
             tinyInstance = null;

--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -68,6 +68,11 @@ angular.module('ui.tinymce', [])
               ed.save();
               updateView();
             });
+            // Update model on node change (to detect color changes)
+            ed.on('nodeChange', function (e) {
+              ed.save();
+              updateView();
+            });
             if (configSetup) {
               configSetup(ed);
             }


### PR DESCRIPTION
I was using version 0.0.4 and noticed the cleanup was missing (and interfering with newer TinyMCE versions) so I added it and later noticed it was already in the latest git commits. Anyway I made this PR because I think that binding to the element is 'cleaner'.
Thanks
Marco