### PR TITLE
Adding bidirectionnal binding with ngModel

### DIFF
--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -23,6 +23,15 @@ angular.module('ui.tinymce', [])
           attrs.$set('id', 'uiTinymce' + generatedIds++);
         }
 
+    	scope.$watch(function(){
+    		return ngModel.$modelValue;
+    	}, function(modelValue) {
+    		var tinyInstance = tinymce.get(attrs.id);
+    		if(tinyInstance && tinyInstance.getContent() !== modelValue) {
+    			tinyInstance.setContent(modelValue);
+    		}
+    	});
+
         if (attrs.uiTinymce) {
           expression = scope.$eval(attrs.uiTinymce);
         } else {


### PR DESCRIPTION
I had a problem using ui-tinymce with ngModel because i binded my tinyMCE with a string fetched from a webservice. I have noticed that when the webservice response after that tinyMCE have render, the string does not appear.
Then I noticed that the binding is unilateral : a change from tinyMCE will be reflected on the scope, but a change on the scope won't be reflected on tinyMCE.
I made this fixe, i am new with AngularJS so it is probably a poor solution. 
I won't be surprise if you deny my pull request, but I wish you will fixe this bug.