### PR TITLE
Make directive work on <div/> and <p/>

### DIFF
--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -12,7 +12,11 @@ angular.module('ui.tinymce', [])
       link: function (scope, elm, attrs, ngModel) {
         var expression, options, tinyInstance,
           updateView = function () {
-            ngModel.$setViewValue(elm.val());
+        	  if(elm.prop("tagName").toLowerCase() === 'textarea') {
+              ngModel.$setViewValue(elm.val());
+            } else {
+              ngModel.$setViewValue(elm.html());
+            }
             if (!scope.$root.$$phase) {
               scope.$apply();
             }


### PR DESCRIPTION
Two way binding fails on the above elements because $('<div>').val() has no meaning. .html() has the appropriate content.