### PR TITLE
Removed delete of user config'd setup method

### DIFF
--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -30,11 +30,11 @@ angular.module('ui.tinymce', [])
         }
 
         // make config'ed setup method available
+        var expressionCopy = angular.extend({}, expression);
         if (expression.setup) {
           var configSetup = expression.setup;
           
           // copy expression
-          var expressionCopy = angular.extend({}, expression);
           delete expressionCopy.setup;
         }
 

--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -32,7 +32,10 @@ angular.module('ui.tinymce', [])
         // make config'ed setup method available
         if (expression.setup) {
           var configSetup = expression.setup;
-          delete expression.setup;
+          
+          // copy expression
+          var expressionCopy = angular.extend({}, expression);
+          delete expressionCopy.setup;
         }
 
         options = {
@@ -76,7 +79,7 @@ angular.module('ui.tinymce', [])
           elements: attrs.id
         };
         // extend options with initial uiTinymceConfig and options from directive attribute value
-        angular.extend(options, uiTinymceConfig, expression);
+        angular.extend(options, uiTinymceConfig, expressionCopy);
         setTimeout(function () {
           tinymce.init(options);
         });


### PR DESCRIPTION
Using deep copy instead. Otherwise, subsequent tinymce inits do not have the user specified setup method.

Fixes issue angular-ui/ui-tinymce#122