### PR TITLE
Building options object in a $timeout

### DIFF
--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -1,9 +1,10 @@
 /**
  * Binds a TinyMCE widget to <textarea> elements.
+ * ui-tinymce-0.0.5 - modified to run 
  */
 angular.module('ui.tinymce', [])
   .value('uiTinymceConfig', {})
-  .directive('uiTinymce', ['uiTinymceConfig', function (uiTinymceConfig) {
+  .directive('uiTinymce', ['uiTinymceConfig', '$timeout', function (uiTinymceConfig, $timeout) {
     uiTinymceConfig = uiTinymceConfig || {};
     var generatedIds = 0;
     return {
@@ -23,61 +24,56 @@ angular.module('ui.tinymce', [])
           attrs.$set('id', 'uiTinymce' + generatedIds++);
         }
 
-        if (attrs.uiTinymce) {
-          expression = scope.$eval(attrs.uiTinymce);
-        } else {
-          expression = {};
-        }
+        // Run in a $timeout so that the attr's will be updated before parsing them
+        $timeout(function() {
+          if (attrs.uiTinymce) {
+            expression = scope.$eval(attrs.uiTinymce);
+          } else {
+            expression = {};
+          }
 
-        // make config'ed setup method available
-        if (expression.setup) {
-          var configSetup = expression.setup;
-          delete expression.setup;
-        }
+          // make config'ed setup method available
+          if (expression.setup) {
+            var configSetup = expression.setup;
+            delete expression.setup;
+          }
 
-        options = {
-          // Update model when calling setContent (such as from the source editor popup)
-          setup: function (ed) {
-            var args;
-            ed.on('init', function(args) {
-              ngModel.$render();
-              ngModel.$setPristine();
-            });
-            // Update model on button click
-            ed.on('ExecCommand', function (e) {
-              ed.save();
-              updateView();
-            });
-            // Update model on keypress
-            ed.on('KeyUp', function (e) {
-              ed.save();
-              updateView();
-            });
-            // Update model on change, i.e. copy/pasted text, plugins altering content
-            ed.on('SetContent', function (e) {
-              if (!e.initial && ngModel.$viewValue !== e.content) {
+          options = {
+            // Update model when calling setContent (such as from the source editor popup)
+            setup: function (ed) {
+              var args;
+              ed.on('init', function(args) {
+                ngModel.$render();
+              });
+              // Update model on button click
+              ed.on('ExecCommand', function (e) {
                 ed.save();
                 updateView();
+              });
+              // Update model on keypress
+              ed.on('KeyUp', function (e) {
+                ed.save();
+                updateView();
+              });
+              // Update model on change, i.e. copy/pasted text, plugins altering content
+              ed.on('SetContent', function (e) {
+                if(!e.initial){
+                  ed.save();
+                  updateView();
+                }
+              });
+              ed.on('blur', function(e) {
+                  elm.blur();
+              });
+              if (configSetup) {
+                configSetup(ed);
               }
-            });
-            ed.on('blur', function(e) {
-                elm.blur();
-            });
-            // Update model when an object has been resized (table, image)
-            ed.on('ObjectResized', function (e) {
-              ed.save();
-              updateView();
-            });
-            if (configSetup) {
-              configSetup(ed);
-            }
-          },
-          mode: 'exact',
-          elements: attrs.id
-        };
-        // extend options with initial uiTinymceConfig and options from directive attribute value
-        angular.extend(options, uiTinymceConfig, expression);
-        setTimeout(function () {
+            },
+            mode: 'exact',
+            elements: attrs.id
+          };
+          // extend options with initial uiTinymceConfig and options from directive attribute value
+          angular.extend(options, uiTinymceConfig, expression);
           tinymce.init(options);
         });
 


### PR DESCRIPTION
When using the ui-tinymce directive inside another directive, the attr is undefined on the first digest cycle. Building the Options object in a $timeout ensures that the attrs have had time to be updated before we try to use them.