### PR TITLE
Fix for ui-tinymce directive disabled state on init

### DIFF
--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -99,7 +99,6 @@ angular.module('ui.tinymce', [])
               });
             }
           },
-          format: 'raw',
           selector: '#' + attrs.id
         };
         // extend options with initial uiTinymceConfig and

--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -110,7 +110,7 @@ angular.module('ui.tinymce', [])
         // re-rendering directive
         $timeout(function() {
           tinymce.init(options);
-          toggleDisable(scope.$eval(attrs.ngDisabled));
+          //toggleDisable(scope.$eval(attrs.ngDisabled));
         });
 
         ngModel.$formatters.unshift(function(modelValue) {
@@ -123,6 +123,7 @@ angular.module('ui.tinymce', [])
 
         ngModel.$render = function() {
           ensureInstance();
+          toggleDisable(scope.$eval(attrs.ngDisabled)); // Long's fix for tinyMce disabled state when initialized https://github.com/angular-ui/ui-tinymce/issues/74
 
           var viewValue = ngModel.$viewValue ?
             $sce.getTrustedHtml(ngModel.$viewValue) : '';


### PR DESCRIPTION
Fixing a bug from production version, toggleDisable did not work in the $timeout, the ensureInstance() method at that point can't actually find the instance. tinymce.get(attrs.id) returns null.