### PR TITLE
Don't set format to raw

### DIFF
--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -99,7 +99,6 @@ angular.module('ui.tinymce', [])
               });
             }
           },
-          format: 'raw',
           selector: '#' + attrs.id
         };
         // extend options with initial uiTinymceConfig and


### PR DESCRIPTION
`format: 'raw'`overwrites the scopes model when used within other directives, ie ui-bootstrap tabs