### PR TITLE
Do not set contenteditable to true when in readonly mode

### DIFF
--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -42,7 +42,7 @@ angular.module('ui.tinymce', [])
           } else {
             ensureInstance();
 
-            if (tinyInstance) {
+            if (tinyInstance && !tinyInstance.settings.readonly) {
               tinyInstance.getBody().setAttribute('contenteditable', true);
             }
           }


### PR DESCRIPTION
This fixes #174 so that you can not change/delete/add text to an inline editor when in readonly mode.