### PR TITLE
Use $digest instead of $apply to avoid unnecessary rootscope digest

### DIFF
--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -28,7 +28,7 @@ angular.module('ui.tinymce', [])
 
             ngModel.$setViewValue(content);
             if (!$rootScope.$$phase) {
-              scope.$apply();
+              scope.$digest();
             }
           };
 


### PR DESCRIPTION
The ```scope.$apply``` call inside ```updateView``` triggers a digest cycle on the rootscope and all descending child scopes. This can cause unnecessary performance issues in large applications, because the scope of the entire application will be re-evaluated whenever a change occurs in the editor.

I suggest changing ```$apply``` to ```$digest```, limiting the digest cycle to the directives own scope, and preventing it from affecting the surrounding application.