### PR TITLE
Fix/issue 224 performance improvement

### DIFF
--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -61,16 +61,16 @@ angular.module('ui.tinymce', [])
         // the entire process doesn't have to happen for every
         // action (i.e. key press, mouse event, etc).
         var doSaveUpdate = (function(doSaveUpdateDelay) {
-            var doSaveUpdateTimer;
-            return function(ed) {
-                $timeout.cancel( doSaveUpdateTimer );
-                doSaveUpdateTimer = $timeout( function() {
-                    return (function(ed) {
-                        ed.save();
-                        updateView(ed);
-                    })(ed);
-                }, doSaveUpdateDelay);
-            };
+          var doSaveUpdateTimer;
+          return function(ed) {
+	    $timeout.cancel(doSaveUpdateTimer);
+	    doSaveUpdateTimer = $timeout(function() {
+	      return (function(ed) {
+	        ed.save();
+	        updateView(ed);
+	      })(ed);
+	    }, doSaveUpdateDelay);
+          };
         })(400); // This could be setup to be an option or attribute.
 
         var setupOptions = {


### PR DESCRIPTION
This is an update to address poor performance when there's  a lot of text in the WYSIWYG editor, as discussed in https://github.com/angular-ui/ui-tinymce/issues/224.

This debounces the save and view update methods, improving UI responsiveness tremendously when typing while there's a large amount of text in the text area.