### PR TITLE
Refactor event handlers

### DIFF
--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -76,7 +76,8 @@ angular.module('ui.tinymce', [])
             // - the content has been reset [SetContent]
             // an object has been resized (table, image) [ObjectResized]
             ed.on('ExecCommand change NodeChange SetContent ObjectResized', function(evt) {
-              if (evt.name !== 'SetContent' || evt.content ) {
+              // update on 'setcontent' only if evt.content is not null
+              if (evt.type !== 'setcontent' || evt.content ) {
                 ed.save();
                 updateView(ed);
               }

--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -80,6 +80,16 @@ angular.module('ui.tinymce', [])
               updateView(ed);
             });
 
+            // Update model on Set content
+            // Only solution I found to fix #210
+            // https://github.com/angular-ui/ui-tinymce/issues/210
+            ed.on('SetContent', function(evt) {
+      				if (evt.content) {
+      					ed.save();
+      					updateView(ed);
+      				}
+      			});
+
             ed.on('blur', function() {
               element[0].blur();
               ngModel.$setTouched();
@@ -113,7 +123,7 @@ angular.module('ui.tinymce', [])
         // re-rendering directive
         $timeout(function() {
           if (options.baseURL){
-            tinymce.baseURL = options.baseURL;            
+            tinymce.baseURL = options.baseURL;
           }
           tinymce.init(options);
           toggleDisable(scope.$eval(attrs.ngDisabled));

--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -69,36 +69,23 @@ angular.module('ui.tinymce', [])
               }
             });
 
-            // Update model on button click
-            ed.on('ExecCommand', function() {
-              ed.save();
-              updateView(ed);
+            // Update model when:
+            // - a button has been clicked [ExecCommand]
+            // - the editor content has been modified [change]
+            // - the node has changed [NodeChange]
+            // - the content has been reset [SetContent]
+            // an object has been resized (table, image) [ObjectResized]
+            ed.on('ExecCommand change NodeChange SetContent ObjectResized', function(evt) {
+              if (evt.name !== 'SetContent' || evt.content ) {
+                ed.save();
+                updateView(ed);
+              }
             });
-
-            // Update model on change
-            ed.on('change NodeChange', function() {
-              ed.save();
-              updateView(ed);
-            });
-
-          // Update model on Set content
-          ed.on('SetContent', function(evt) {
-            if (evt.content) {
-              ed.save();
-              updateView(ed);
-            }
-          });
 
             ed.on('blur', function() {
               element[0].blur();
               ngModel.$setTouched();
               scope.$digest();
-            });
-
-            // Update model when an object has been resized (table, image)
-            ed.on('ObjectResized', function() {
-              ed.save();
-              updateView(ed);
             });
 
             ed.on('remove', function() {

--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -82,8 +82,6 @@ angular.module('ui.tinymce', [])
             });
 
           // Update model on Set content
-          // Only solution I found to fix #210
-          // https://github.com/angular-ui/ui-tinymce/issues/210
           ed.on('SetContent', function(evt) {
             if (evt.content) {
               ed.save();

--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -80,15 +80,15 @@ angular.module('ui.tinymce', [])
               updateView(ed);
             });
 
-            // Update model on Set content
-            // Only solution I found to fix #210
-            // https://github.com/angular-ui/ui-tinymce/issues/210
-            ed.on('SetContent', function(evt) {
-      				if (evt.content) {
-      					ed.save();
-      					updateView(ed);
-      				}
-      			});
+          // Update model on Set content
+          // Only solution I found to fix #210
+          // https://github.com/angular-ui/ui-tinymce/issues/210
+          ed.on('SetContent', function(evt) {
+            if (evt.content) {
+              ed.save();
+              updateView(ed);
+            }
+          });
 
             ed.on('blur', function() {
               element[0].blur();


### PR DESCRIPTION
@deeg , 

As you can see, we can refactor events handler that ends with saving model and updating view.

However, before merging this PR, please consider merging my previous PR, that contain changes on the same block of code.
This PR is from a local branch `refactor-event-handlers` on my fork that come from the branch `bugfix-#210-model-not-saved-after-inserting-images` that is my previous PR.

In one word, this PR is made on top of my previous PR, but in a new topic branch

> see my previous PR: https://github.com/angular-ui/ui-tinymce/pull/232

And my log graph representing my history by branches  to illustrate `master -> bugfix-#210-model-not-saved-after-inserting-images -> refactor-event-handlers`

    * 73d05cf (HEAD, gh-rbecheras/refactor-event-handlers, refactor-event-handlers) refactoring event handl
    * d6ce122 (gh-rbecheras/bugfix-#210-model-not-saved-after-inserting-images, bugfix-#210-model-not-saved-after-inserting-images) remove unecessa
    *   3c499d9 Merge branch 'master' into bugfix-#210-model-not-saved-after-inserting-images                                                      
    |\                                                                                                                                             
    | * fa0be56 (tag: v0.0.13, gh-upstream/master, master) chore(release): Update versions                
    | * da64eb9 Added priority to directive                                                                                                        
    * | 61c8e66 Fix #210
    |/  
    * a5f8d66 bug(model): Touched value now set correctly.
