### PR TITLE
Allow angular 1.4 or higher as dependency in bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
     "package.json"
   ],
   "dependencies": {
-    "angular": "~1.4.x",
+    "angular": ">=1.4.0",
     "tinymce-dist": "~4.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The Readme states "AngularJS 1.4.x or higher". This PR fixes this for the bower declaration. Also #246 .