### PR TITLE
add optional debouncing

### DIFF
--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -91,6 +91,10 @@ angular.module('ui.tinymce', [])
             // - the node has changed [NodeChange]
             // - an object has been resized (table, image) [ObjectResized]
             ed.on('ExecCommand change NodeChange ObjectResized', function() {
+              if (!options.debounce) {
+              	updateView(ed);
+              	return;
+              }
               debouncedUpdate(ed);
             });
 


### PR DESCRIPTION
Debouncing will no longer be a default action unless the user specifies `debounce: true` in the options. Relating to issue #256 

Motivation: Debouncing was causing unexpected behavior where data was being excluded when submitting or saving text from TinyMCE. Debouncing should be optional.