### PR TITLE
Do not set the parent form to pristine on init

### DIFF
--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -12,15 +12,14 @@ angular.module('ui.tinymce', [])
     }
 
     return {
-      require: ['ngModel', '^?form'],
+      require: ['ngModel'],
       priority: 599,
       link: function(scope, element, attrs, ctrls) {
         if (!$window.tinymce) {
           return;
         }
 
-        var ngModel = ctrls[0],
-          form = ctrls[1] || null;
+        var ngModel = ctrls[0];
 
         var expression, options = {
           debounce: true
@@ -81,10 +80,7 @@ angular.module('ui.tinymce', [])
             ed.on('init', function() {
               ngModel.$render();
               ngModel.$setPristine();
-                ngModel.$setUntouched();
-              if (form) {
-                form.$setPristine();
-              }
+              ngModel.$setUntouched();
             });
 
             // Update model when:


### PR DESCRIPTION
The field should not control form state.

The issue was found when enabling ui-tinymce directive inside a form, which had other fields. When it enables, all other fields are set to pristine, since ui-tinymce set the form to pristine.

This behaviour has been removed.