### PR TITLE
Remove trusted option, $sce is used by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,11 @@ scope.tinymceOptions = {
   }
 };
 ```
+By default all TinyMCE content that is set to `ngModel` will be whitelisted by `$sce`.
 
 In addition, it supports these additional optional options
 
 - `format` Format to get content as, i.e. 'raw' for raw HTML, or 'text' for text only. Defaults to 'html'. Documentation [here](http://www.tinymce.com/wiki.php/api4:method.tinymce.Editor.getContent)
-- `trusted` When `true`, all TinyMCE content that is set to `ngModel` will be whitelisted by `$sce`
 - `baseURL` This will set [baseURL property on the EditorManager](https://www.tinymce.com/docs/api/class/tinymce.editormanager/)
 - `debounce` This will debounce the model update which helps with performance of editors with large text. Defaults to true.
 

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -14,7 +14,7 @@
 </head>
 <body ng-app="ui.tinymce" ng-controller="DemoCtrl as demo">
   <form method="post">
-    <textarea ui-tinymce="{trusted: true}"
+    <textarea ui-tinymce
       ng-model="demo.tinymce"
       ng-change="demo.updateHtml()"></textarea>
   </form>


### PR DESCRIPTION
See Issue #208, trusted option logic was removed in https://github.com/angular-ui/ui-tinymce/commit/23692d5fbe7adee81ac9ad7aab10b67d8eb8ae0b but documentation was never updated to refelct the change.