### PR TITLE
Added option updateOnBlurOnly to update ngmodel only on editor blur

### DIFF
--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -87,19 +87,21 @@ angular.module('ui.tinymce', [])
               }
             });
 
-            // Update model when:
-            // - a button has been clicked [ExecCommand]
-            // - the editor content has been modified [change]
-            // - the node has changed [NodeChange]
-            // - an object has been resized (table, image) [ObjectResized]
-            ed.on('ExecCommand change NodeChange ObjectResized', function() {
-              if (!options.debounce) {
-                ed.save();
-                updateView(ed);
-              	return;
-              }
-              debouncedUpdate(ed);
-            });
+            if (!options.updateOnBlurOnly) {
+                // Update model when:
+                // - a button has been clicked [ExecCommand]
+                // - the editor content has been modified [change]
+                // - the node has changed [NodeChange]
+                // - an object has been resized (table, image) [ObjectResized]
+                ed.on('ExecCommand change NodeChange ObjectResized', function() {
+                  if (!options.debounce) {
+                    ed.save();
+                    updateView(ed);
+                  	return;
+                  }
+                  debouncedUpdate(ed);
+                });
+            }
 
             ed.on('blur', function() {
               element[0].blur();


### PR DESCRIPTION
Updating ngmodel can be an expensive operation, and sometimes it is sufficient to update it when editing is done - on blur event.

My particular case was that if there are many editors in the page, in IE11 when writing something in the editor a big lag is visible.

This pull request allows to fix this problem.