### PR TITLE
Allow for global config

### DIFF
--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -2,7 +2,7 @@
  * Binds a TinyMCE widget to <textarea> elements.
  */
 angular.module('ui.tinymce', [])
-  .value('uiTinymceConfig', {})
+  .constant('uiTinymceConfig', {})
   .directive('uiTinymce', ['$rootScope', '$compile', '$timeout', '$window', '$sce', 'uiTinymceConfig', function($rootScope, $compile, $timeout, $window, $sce, uiTinymceConfig) {
     uiTinymceConfig = uiTinymceConfig || {};
     var generatedIds = 0;


### PR DESCRIPTION
This is a **very small change** that we have to make in our app to allow us to globally configure the options for TinyMCE once instead of doing it again and again in each controller.

Now we can do the following:

```js
angular
  .module("ui.tinymce")
  .config([
      "uiTinymceConfig", (uiTinymceConfig) => {
        uiTinymceConfig.toolbar = "undo redo | bold italic bullist numlist blockquote styleselect removeformat | charmap link | spellchecker";
        uiTinymceConfig.skin = "lightgray";
        uiTinymceConfig.theme = "modern";
        //etc...
    }
  ]);
```