### PR TITLE
Do not save dirty changes automatically when save plugin is present

### DIFF
--- a/src/tinymce.js
+++ b/src/tinymce.js
@@ -62,11 +62,16 @@ angular.module('ui.tinymce', [])
         var debouncedUpdate = (function(debouncedUpdateDelay) {
           var debouncedUpdateTimer;
           return function(ed) {
+            var tinymcePlugins = tinyInstance.settings.plugins
+              ? tinyInstance.settings.plugins.split(' ')
+              : []
 	        $timeout.cancel(debouncedUpdateTimer);
 	         debouncedUpdateTimer = $timeout(function() {
               return (function(ed) {
                 if (ed.isDirty()) {
-                  ed.save();
+                  if (tinymcePlugins.indexOf('save') === -1) {
+                    ed.save();
+                  }
                   updateView(ed);
                 }
               })(ed);

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -6,6 +6,7 @@ module.exports = function (config) {
       'bower_components/angular/angular.js',
       'bower_components/angular-mocks/angular-mocks.js',
       'bower_components/tinymce/tinymce.min.js',
+      'bower_components/tinymce/plugins/save/plugin.min.js',
       'src/tinymce.js',
       'test/*.spec.js',
       {pattern: 'bower_components/tinymce/themes/**', included: false},

--- a/test/tinymce.spec.js
+++ b/test/tinymce.spec.js
@@ -181,4 +181,50 @@ describe('uiTinymce', function () {
 	    expect(id2).not.toEqual(id3);
 	    expect(id3).not.toEqual(id4);
   });
+
+  it('does not automatically save the dirty changes when save plugin is present', function () {
+    // Given a tinymce editor is present on a page with a plugin to allow saving externally
+    scope.options = {
+      plugins: 'save',
+      setup: function (ed) {}
+    };
+    spyOn(scope.options, 'setup').and.callThrough()
+    element = $compile('<form><textarea ui-tinymce="options" data-ng-model="foo_1"</textarea></form>')(scope);
+    angular.element(document.getElementsByTagName('body')[0]).append(element);
+    scope.$apply();
+    $timeout.flush();
+
+    // When there is a change event on editor
+    var editor = scope.options.setup.calls.allArgs()[0][0];
+    spyOn(editor, 'isDirty').and.returnValue(true);
+    spyOn(editor, 'save');
+    $timeout.flush(); // This will ensure that debouncedUpdateTimer timer function is executed which was setup on 'change' event
+
+    // Then I see that content is not automatically saved when content is dirty
+    expect(editor.isDirty).toHaveBeenCalled();
+    expect(editor.save).not.toHaveBeenCalled();
+  });
+
+  it('automatically saves the dirty changes when save plugin is not present', function () {
+    // Given a tinymce editor is present on a page without a 'save' plugin
+    scope.options = {
+      plugins: '',
+      setup: function (ed) {}
+    };
+    spyOn(scope.options, 'setup').and.callThrough()
+    element = $compile('<form><textarea ui-tinymce="options" data-ng-model="foo_1"</textarea></form>')(scope);
+    angular.element(document.getElementsByTagName('body')[0]).append(element);
+    scope.$apply();
+    $timeout.flush();
+
+    // When there is a change event on editor
+    var editor = scope.options.setup.calls.allArgs()[0][0];
+    spyOn(editor, 'isDirty').and.returnValue(true);
+    spyOn(editor, 'save');
+    $timeout.flush(); // This will ensure that debouncedUpdateTimer timer function is executed which was setup on 'change' event
+
+    // Then I see that content is automatically saved when content is dirty
+    expect(editor.isDirty).toHaveBeenCalled();
+    expect(editor.save).toHaveBeenCalled();
+  })
 });


### PR DESCRIPTION
## Description

When there is a 'save' plugin present in tinymce then the intention is to control the saving operation using a callback or saving via a button.
In the directive, debouncedUpdateTimer function is automatically saving the editor changes on a change event which should not happen if 'save' plugin is used. Due to this, save_onsavecallback callback is not getting called because there are no dirty changes.

## Issue
 #260 

## Plunkr link with the implemented changes
https://plnkr.co/edit/u3iFVfv8J3u95AAm14Rb?p=preview